### PR TITLE
Update for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>24</version>
+    <version>28</version>
   </parent>
 
   <groupId>io.takari.maven.plugins</groupId>
@@ -24,11 +24,13 @@
   <packaging>pom</packaging>
 
   <properties>
-    <mavenVersion>3.3.1</mavenVersion>
-    <sisuVersion>0.3.0</sisuVersion>
-    <sisuGuiceVersion>3.2.5</sisuGuiceVersion>
-    <aetherVersion>1.0.2.v20150114</aetherVersion>
-    <slf4jVersion>1.7.9</slf4jVersion>
+    <mavenVersion>3.6.3</mavenVersion>
+    <sisuVersion>0.3.4</sisuVersion>
+    <sisuGuiceVersion>4.2.0</sisuGuiceVersion>
+    <aetherVersion>1.4.1</aetherVersion>
+    <plexusVersion>3.3.0</plexusVersion>
+    <slf4jVersion>1.7.30</slf4jVersion>
+    <takariLifecycleVersion>1.13.9</takariLifecycleVersion>
   </properties>
 
   <modules>
@@ -47,7 +49,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>3.0.21</version>
+        <version>${plexusVersion}</version>
       </dependency>
 
       <!-- unit testing -->
@@ -68,7 +70,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
-        <artifactId>maven-aether-provider</artifactId>
+        <artifactId>maven-resolver-provider</artifactId>
         <version>${mavenVersion}</version>
       </dependency>
       <dependency>
@@ -92,8 +94,8 @@
         <version>${mavenVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-api</artifactId>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-api</artifactId>
         <version>${aetherVersion}</version>
       </dependency>
       <dependency>
@@ -112,12 +114,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-exec</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-classworlds</artifactId>
-        <version>2.5.2</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>io.takari.m2e.workspace</groupId>
@@ -129,7 +131,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.9</version>
+        <version>1.19</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/takari-plugin-testing-its/pom.xml
+++ b/takari-plugin-testing-its/pom.xml
@@ -72,7 +72,7 @@
                 <artifactItem>
                   <groupId>org.apache.maven</groupId>
                   <artifactId>apache-maven</artifactId>
-                  <version>3.2.5</version>
+                  <version>3.6.3</version>
                   <classifier>bin</classifier>
                   <type>tar.gz</type>
                 </artifactItem>

--- a/takari-plugin-testing-its/src/test/java/io/takari/maven/testing/test/IntegrationTest.java
+++ b/takari-plugin-testing-its/src/test/java/io/takari/maven/testing/test/IntegrationTest.java
@@ -20,7 +20,7 @@ import io.takari.maven.testing.executor.MavenRuntime;
 
 /**
  * <ul>
- * <li>The test project is built with maven 3.2.5.</li>
+ * <li>The test project is built with maven 3.6.3.</li>
  * <li>The test project is built against specific versions of maven, as specified in individual test
  * methods</li>
  * <li>The test project is not able to resolve test harness from the reactor, hence the outer build
@@ -33,19 +33,7 @@ public class IntegrationTest {
   @Parameters(name = "{0}")
   public static List<Object[]> versions() {
     List<Object[]> parameters = new ArrayList<>();
-    parameters.add(new Object[] {"3.0.5"});
-    // parameters.add(new Object[] {"3.1.0"}); not supported unless someone asks real nice
-    parameters.add(new Object[] {"3.1.1"});
-    // parameters.add(new Object[] {"3.2.1"}); see https://issues.apache.org/jira/browse/MNG-5591
-    parameters.add(new Object[] {"3.2.2"});
-    parameters.add(new Object[] {"3.2.3"});
-    // parameters.add(new Object[] {"3.2.4"}); was never released
-    parameters.add(new Object[] {"3.2.5"});
-    parameters.add(new Object[] {"3.3.1"});
-    // parameters.add(new Object[] {"3.3.2"}); was never released
-    parameters.add(new Object[] {"3.3.3"});
-    parameters.add(new Object[] {"3.3.9"});
-    parameters.add(new Object[] {"3.5.0"});
+    parameters.add(new Object[] {"3.6.3"});
     return parameters;
   }
 
@@ -58,7 +46,7 @@ public class IntegrationTest {
 
   public IntegrationTest(String version) throws Exception {
     this.version = version;
-    File mavenHome = new File("target/apache-maven-3.2.5");
+    File mavenHome = new File("target/apache-maven-3.6.3");
     this.maven = MavenRuntime.builder(mavenHome, null).forkedBuilder().build();
   }
 

--- a/takari-plugin-testing-its/src/test/projects/basic/pom.xml
+++ b/takari-plugin-testing-its/src/test/projects/basic/pom.xml
@@ -18,9 +18,9 @@
   <packaging>takari-maven-plugin</packaging>
 
   <properties>
-    <takariLifecycleVersion>1.11.7</takariLifecycleVersion>
-    <mavenVersion>3.2.5</mavenVersion>
-    <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
+    <takariLifecycleVersion>1.13.9</takariLifecycleVersion>
+    <mavenVersion>3.6.3</mavenVersion>
+    <mavenPluginPluginVersion>3.6.0</mavenPluginPluginVersion>
     <it-project.version>2.6.0-SNAPSHOT</it-project.version>
   </properties>
 

--- a/takari-plugin-testing-its/src/test/projects/classloading/pom.xml
+++ b/takari-plugin-testing-its/src/test/projects/classloading/pom.xml
@@ -17,7 +17,7 @@
   <artifactId>classloading</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>takari-maven-plugin</packaging>
-  
+
   <!--
     | the point of this test is to demonstrate test dependencies "leakage"
     | into integration tests, as explained in classloading.md.
@@ -28,13 +28,13 @@
     | 3.0.5 or 3.2.5 integration test will "see" unexpected aether classes.
     |
     | 3.2.6-SNAPSHOT is not affected by the problem and passes regardless of
-    | version of maven used to compile. 
+    | version of maven used to compile.
    -->
 
   <properties>
-    <takariLifecycleVersion>1.10.0</takariLifecycleVersion>
-    <mavenVersion>3.2.5</mavenVersion>
-    <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
+    <takariLifecycleVersion>1.13.9</takariLifecycleVersion>
+    <mavenVersion>3.6.3</mavenVersion>
+    <mavenPluginPluginVersion>3.6.0</mavenPluginPluginVersion>
     <it-project.version>2.0.0-SNAPSHOT</it-project.version>
   </properties>
 

--- a/takari-plugin-testing-its/src/test/projects/guicescopes/pom.xml
+++ b/takari-plugin-testing-its/src/test/projects/guicescopes/pom.xml
@@ -18,9 +18,9 @@
   <packaging>takari-maven-plugin</packaging>
 
   <properties>
-    <takariLifecycleVersion>1.11.7</takariLifecycleVersion>
-    <mavenVersion>3.2.2</mavenVersion>
-    <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
+    <takariLifecycleVersion>1.13.9</takariLifecycleVersion>
+    <mavenVersion>3.6.3</mavenVersion>
+    <mavenPluginPluginVersion>3.6.0</mavenPluginPluginVersion>
     <it-project.version>2.5.0-SNAPSHOT</it-project.version>
   </properties>
 

--- a/takari-plugin-testing-its/src/test/projects/pomconfig/pom.xml
+++ b/takari-plugin-testing-its/src/test/projects/pomconfig/pom.xml
@@ -18,9 +18,9 @@
   <packaging>takari-maven-plugin</packaging>
 
   <properties>
-    <takariLifecycleVersion>1.11.7</takariLifecycleVersion>
-    <mavenVersion>3.3.3</mavenVersion>
-    <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
+    <takariLifecycleVersion>1.13.9</takariLifecycleVersion>
+    <mavenVersion>3.6.3</mavenVersion>
+    <mavenPluginPluginVersion>3.6.0</mavenPluginPluginVersion>
     <it-project.version>2.6.0-SNAPSHOT</it-project.version>
   </properties>
 

--- a/takari-plugin-testing-its/src/test/projects/settings/pom.xml
+++ b/takari-plugin-testing-its/src/test/projects/settings/pom.xml
@@ -18,9 +18,9 @@
   <packaging>takari-maven-plugin</packaging>
 
   <properties>
-    <takariLifecycleVersion>1.11.10</takariLifecycleVersion>
-    <mavenVersion>3.2.5</mavenVersion>
-    <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
+    <takariLifecycleVersion>1.13.9</takariLifecycleVersion>
+    <mavenVersion>3.6.3</mavenVersion>
+    <mavenPluginPluginVersion>3.6.0</mavenPluginPluginVersion>
     <it-project.version>2.8.0-SNAPSHOT</it-project.version>
   </properties>
 

--- a/takari-plugin-testing/.settings/org.eclipse.jdt.core.prefs
+++ b/takari-plugin-testing/.settings/org.eclipse.jdt.core.prefs
@@ -89,6 +89,7 @@ org.eclipse.jdt.core.compiler.problem.unusedPrivateMember=warning
 org.eclipse.jdt.core.compiler.problem.unusedTypeParameter=ignore
 org.eclipse.jdt.core.compiler.problem.unusedWarningToken=warning
 org.eclipse.jdt.core.compiler.problem.varargsArgumentNeedCast=error
+org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=1.7
 org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines=2147483647
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false

--- a/takari-plugin-testing/pom.xml
+++ b/takari-plugin-testing/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
+      <artifactId>maven-resolver-provider</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -68,8 +68,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
In order to build this successfully with a JDK 11 Maven and all its
dependencies must be updated to a Maven version which supports JDK 11.

This also drops support for older Maven versions.