### PR TITLE
Add support for JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,14 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.13.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.8.2</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ maven-plugin-testing-harness and maven-verifier.
 Features and benefits
 
 * Convenient junit4-based API
+* Convenient junit5-based API
 * Flexible unit test mojo configuration API simplifies test project setup 
   and maintenance
 * Collocate main and test code in the same build module
@@ -44,7 +45,7 @@ pom.xml
       <scope>test</scope>
     </dependency>
 
-test code
+JUnit 4 test code
 
     public class PluginUnitTest {
       @Rule
@@ -55,6 +56,23 @@ test code
     
       @Test
       public void test() throws Exception {
+        File basedir = resources.getBasedir("testproject");
+        maven.executeMojo(basedir, "mymojo", newParameter("name", "value");
+        assertFilesPresent(basedir, "target/output.txt");
+      }
+    }
+
+JUnit 5 test code
+
+    class PluginUnitTest {
+      @RegisterExtension
+      final TestResources5 resources = new TestResources5();
+    
+      @RegisterExtension
+      final TestMavenRuntime5 maven = new TestMavenRuntime5();
+    
+      @Test
+      void test() throws Exception {
         File basedir = resources.getBasedir("testproject");
         maven.executeMojo(basedir, "mymojo", newParameter("name", "value");
         assertFilesPresent(basedir, "target/output.txt");
@@ -81,7 +99,7 @@ pom.xml
       <scope>test</scope>
     </dependency>
 
-test
+JUnit 4 test
 
     @RunWith(MavenJUnitTestRunner.class)
     @MavenVersions({"3.2.3", "3.2.5"})
@@ -97,6 +115,31 @@ test
     
       @Test
       public void test() throws Exception {
+        File basedir = resources.getBasedir("basic");
+        maven.forProject(basedir)
+          .withCliOption("-Dproperty=value")
+          .withCliOption("-X")
+          .execute("deploy")
+          .assertErrorFreeLog()
+          .assertLogText("some build message");
+      }
+    }
+
+JUnit 5 test
+
+    @MavenVersions({"3.2.3", "3.2.5"})
+    class PluginIntegrationTest {
+      @RegisterExtension
+      final TestResources5 resources = new TestResources5();
+    
+      private final MavenRuntime maven;
+    
+      PluginIntegrationTest(MavenRuntimeBuilder mavenBuilder) {
+        this.maven = mavenBuilder.withCliOptions("-B", "-U").build();
+      }
+    
+      @MavenPluginTest
+      void test() throws Exception {
         File basedir = resources.getBasedir("basic");
         maven.forProject(basedir)
           .withCliOption("-Dproperty=value")

--- a/takari-plugin-testing-its/pom.xml
+++ b/takari-plugin-testing-its/pom.xml
@@ -25,12 +25,14 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.takari.maven.plugins</groupId>
       <artifactId>takari-plugin-testing</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.takari.maven.plugins</groupId>

--- a/takari-plugin-testing-its/pom.xml
+++ b/takari-plugin-testing-its/pom.xml
@@ -27,6 +27,27 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- to run the JUnit 4 tests -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>io.takari.maven.plugins</groupId>

--- a/takari-plugin-testing-its/src/test/java/io/takari/maven/testing/test/JUnit5IntegrationTests.java
+++ b/takari-plugin-testing-its/src/test/java/io/takari/maven/testing/test/JUnit5IntegrationTests.java
@@ -1,0 +1,78 @@
+package io.takari.maven.testing.test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.takari.maven.testing.TestResources5;
+import io.takari.maven.testing.executor.MavenInstallations;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenPluginTest;
+
+@MavenVersions("3.8.4")
+@MavenInstallations("target/apache-maven-3.6.3")
+public class JUnit5IntegrationTests {
+
+  @RegisterExtension
+  final TestResources5 resources = new TestResources5();
+
+  private final MavenRuntime maven;
+
+  private final String version;
+
+  JUnit5IntegrationTests(MavenRuntimeBuilder builder) throws Exception {
+    this.maven = builder
+            .withCliOptions("-B", "-e")
+            .build();
+    this.version = this.maven.getMavenVersion();
+  }
+
+  @MavenPluginTest
+  void testBasic() throws Exception {
+    File basedir = this.resources.getBasedir("basic");
+    this.write(new File(basedir, "src/test/java/basic/TargetVersion.java"),
+        "package basic; class TargetVersion { static final String VERSION = \"" + this.version + "\"; }");
+
+    this.maven.forProject(basedir) //
+        .execute("package") //
+        .assertErrorFreeLog();
+  }
+
+  private void write(File file, String string) throws IOException {
+    Files.write(file.toPath(), string.getBytes(UTF_8));
+  }
+
+  @MavenPluginTest
+  void testGuiceScopes() throws Exception {
+    // scopes were introduced in 3.2.1 https://issues.apache.org/jira/browse/MNG-5530
+    Assumptions.assumeFalse(this.version.startsWith("3.0") || this.version.startsWith("3.1"));
+
+    File basedir = this.resources.getBasedir("guicescopes");
+    this.maven.forProject(basedir) //
+        .execute("package") //
+        .assertErrorFreeLog();
+  }
+
+  @MavenPluginTest
+  void testPomConfig() throws Exception {
+    File basedir = this.resources.getBasedir("pomconfig");
+    this.maven.forProject(basedir) //
+        .execute("package") //
+        .assertErrorFreeLog();
+  }
+
+  @MavenPluginTest
+  void testUnitTestHarnessHonoursUserSettings() throws Exception {
+    File basedir = this.resources.getBasedir("settings");
+    this.maven.forProject(basedir) //
+        .execute("test") //
+        .assertErrorFreeLog();
+  }
+}

--- a/takari-plugin-testing-its/src/test/java/io/takari/maven/testing/test/JUnit5UnitTests.java
+++ b/takari-plugin-testing-its/src/test/java/io/takari/maven/testing/test/JUnit5UnitTests.java
@@ -1,0 +1,106 @@
+package io.takari.maven.testing.test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import io.takari.maven.testing.TestResources5;
+import io.takari.maven.testing.executor.MavenRuntime;
+
+/**
+ * <ul>
+ * <li>The test project is built with maven 3.6.3.</li>
+ * <li>The test project is built against specific versions of maven, as specified in individual test
+ * methods</li>
+ * <li>The test project is not able to resolve test harness from the reactor, hence the outer build
+ * must run at least install phase.</li>
+ * </ul>
+ */
+class JUnit5UnitTests {
+
+  @RegisterExtension
+  final TestResources5 resources = new TestResources5();
+
+  @ParameterizedTest
+  @ArgumentsSource(MavenVersionsSource.class)
+  void testBasic(MavenRuntime maven, String version) throws Exception {
+    File basedir = this.resources.getBasedir("basic");
+    this.write(new File(basedir, "src/test/java/basic/TargetVersion.java"),
+        "package basic; class TargetVersion { static final String VERSION = \"" + version + "\"; }");
+    maven.forProject(basedir) //
+        .withCliOptions("-B", "-e", "-DmavenVersion=" + version) //
+        .execute("package") //
+        .assertErrorFreeLog();
+  }
+
+  private void write(File file, String string) throws IOException {
+    Files.write(file.toPath(), string.getBytes(UTF_8));
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(MavenVersionsSource.class)
+  void testGuiceScopes(MavenRuntime maven, String version) throws Exception {
+    // scopes were introduced in 3.2.1 https://issues.apache.org/jira/browse/MNG-5530
+    assumeFalse(version.startsWith("3.0") || version.startsWith("3.1"));
+
+    File basedir = this.resources.getBasedir("guicescopes");
+    maven.forProject(basedir) //
+        .withCliOptions("-B", "-e", "-DmavenVersion=" + version) //
+        .execute("package") //
+        .assertErrorFreeLog();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(MavenVersionsSource.class)
+  void testPomConfig(MavenRuntime maven, String version) throws Exception {
+    File basedir = this.resources.getBasedir("pomconfig");
+    maven.forProject(basedir) //
+        .withCliOptions("-B", "-e", "-DmavenVersion=" + version) //
+        .execute("package") //
+        .assertErrorFreeLog();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(MavenVersionsSource.class)
+  void testUnitTestHarnessHonoursUserSettings(MavenRuntime maven, String version) throws Exception {
+    File basedir = this.resources.getBasedir("settings");
+    maven.forProject(basedir) //
+        .withCliOptions("-B", "-e", "-DmavenVersion=" + version) //
+        .execute("test") //
+        .assertErrorFreeLog();
+  }
+
+  static final class MavenVersionsSource implements ArgumentsProvider {
+
+    private List<String> getMavenVersions() {
+      return Collections.singletonList("3.6.3");
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments( ExtensionContext context) throws Exception {
+      List<String> mavenVersions = this.getMavenVersions();
+      List<Arguments> arguments = new ArrayList<>(mavenVersions.size());
+      for (String version : mavenVersions) {
+        File mavenHome = new File("target/apache-maven-" + version);
+        MavenRuntime maven = MavenRuntime.builder(mavenHome, null).forkedBuilder().build();
+        arguments.add(Arguments.of(maven, version));
+      }
+      return arguments.stream();
+    }
+
+  }
+}

--- a/takari-plugin-testing/pom.xml
+++ b/takari-plugin-testing/pom.xml
@@ -27,6 +27,11 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
     </dependency>

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/AbstractTestMavenRuntime.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/AbstractTestMavenRuntime.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) 2014 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import com.google.inject.Module;
+
+public abstract class AbstractTestMavenRuntime {
+
+  private static final DefaultArtifactVersion MAVEN_VERSION;
+
+  static {
+    DefaultArtifactVersion version = null;
+    String path = "/META-INF/maven/org.apache.maven/maven-core/pom.properties";
+    try (InputStream is = TestMavenRuntime.class.getResourceAsStream(path)) {
+      Properties properties = new Properties();
+      if (is != null) {
+        properties.load(is);
+      }
+      String property = properties.getProperty("version");
+      if (property != null) {
+        version = new DefaultArtifactVersion(property);
+      }
+    } catch (IOException e) {
+      // odd, where did this come from
+    }
+    MAVEN_VERSION = version;
+  }
+
+  private static interface RuntimeFactory {
+    MavenRuntime newInstance(Module[] modules) throws Exception;
+  }
+
+  // ordered map of supported maven runtime factories
+  private static final Map<VersionRange, RuntimeFactory> FACTORIES;
+
+  static {
+    Map<VersionRange, RuntimeFactory> factories = new LinkedHashMap<>();
+    try {
+      factories.put(VersionRange.createFromVersionSpec("[3.0,3.1.1)"), new RuntimeFactory() {
+        @Override
+        public MavenRuntime newInstance(Module[] modules) throws Exception {
+          return new Maven30xRuntime(modules);
+        }
+      });
+      factories.put(VersionRange.createFromVersionSpec("[3.1.1,3.2.1)"), new RuntimeFactory() {
+        @Override
+        public MavenRuntime newInstance(Module[] modules) throws Exception {
+          return new Maven311Runtime(modules);
+        }
+      });
+      factories.put(VersionRange.createFromVersionSpec("[3.2.1,3.2.5)"), new RuntimeFactory() {
+        @Override
+        public MavenRuntime newInstance(Module[] modules) throws Exception {
+          return Maven321Runtime.create(modules);
+        }
+      });
+      factories.put(VersionRange.createFromVersionSpec("[3.2.5]"), new RuntimeFactory() {
+        @Override
+        public MavenRuntime newInstance(Module[] modules) throws Exception {
+          return new Maven325Runtime(modules);
+        }
+      });
+      // the last entry is expected to handle everything else
+      factories.put(VersionRange.createFromVersionSpec("(3.2.5,]"), new RuntimeFactory() {
+        @Override
+        public MavenRuntime newInstance(Module[] modules) throws Exception {
+          return new Maven331Runtime(modules);
+        }
+      });
+    } catch (InvalidVersionSpecificationException e) {
+      throw new RuntimeException(e);
+    }
+    FACTORIES = Collections.unmodifiableMap(factories);
+  }
+
+  private final Module[] modules;
+  private MavenRuntime runtime;
+
+  public class TestDependency {
+
+    private final File file;
+    private String groupId = "test";
+    private String artifactId;
+    private String classifier;
+    private String version = "1.0";
+    private String type = "jar";
+    private String scope = Artifact.SCOPE_COMPILE;
+    private boolean optional;
+
+    private TestDependency(File artifact) {
+      this.file = artifact;
+      this.artifactId = artifact.getName();
+    }
+
+    public TestDependency setArtifactId(String artifactId) {
+      this.artifactId = artifactId;
+
+      return this;
+    }
+
+    public TestDependency setGroupId(String groupId) {
+      this.groupId = groupId;
+
+      return this;
+    }
+
+    public TestDependency setVersion(String version) {
+      this.version = version;
+
+      return this;
+    }
+
+    public TestDependency setType(String type) {
+      this.type = type;
+
+      return this;
+    }
+
+    public TestDependency setOptional(boolean optional) {
+      this.optional = optional;
+
+      return this;
+    }
+
+    public TestDependency setClassifier(String classifier) {
+      this.classifier = classifier;
+
+      return this;
+    }
+
+    public TestDependency setScope(String scope) {
+      this.scope = scope;
+
+      return this;
+    }
+
+    public TestDependency addTo(MavenProject project) throws Exception {
+      return addTo(project, true);
+    }
+
+    public TestDependency addTo(MavenProject project, boolean direct) throws Exception {
+      ArtifactHandler handler = getContainer().lookup(ArtifactHandler.class, type);
+      DefaultArtifact artifact = new DefaultArtifact(groupId, artifactId, version, scope, type, classifier, handler);
+      artifact.setFile(file);
+      artifact.setOptional(optional);
+      Set<Artifact> artifacts = project.getArtifacts();
+      artifacts.add(artifact);
+      project.setArtifacts(artifacts);
+      if (direct) {
+        Set<Artifact> directDependencies = project.getDependencyArtifacts();
+        directDependencies = directDependencies == null ? new LinkedHashSet<Artifact>() : new LinkedHashSet<>(directDependencies);
+        directDependencies.add(artifact);
+        project.setDependencyArtifacts(directDependencies);
+      }
+
+      return this;
+    }
+  }
+
+  AbstractTestMavenRuntime() {
+    this(new Module[0]);
+  }
+
+  AbstractTestMavenRuntime(Module... modules) {
+    this.modules = modules;
+  }
+
+  void createMavenRuntime() throws Exception {
+    runtime = newMavenRuntime(modules);
+  }
+
+  void shutDownMavenRuntime() {
+    runtime.shutdown();
+    runtime = null;
+  }
+
+  private MavenRuntime newMavenRuntime(Module[] modules) throws Exception {
+    for (Map.Entry<VersionRange, RuntimeFactory> entry : FACTORIES.entrySet()) {
+      if (entry.getKey().containsVersion(MAVEN_VERSION)) {
+        return entry.getValue().newInstance(modules);
+      }
+    }
+    throw new AssertionError(String.format("Maven version %s is not supported, supprted versions: %s", MAVEN_VERSION, FACTORIES.entrySet()));
+  }
+
+  public MavenProject readMavenProject(File basedir) throws Exception {
+    MavenProject project = runtime.readMavenProject(basedir);
+    Objects.requireNonNull(project);
+    return project;
+  }
+
+  public MavenSession newMavenSession(MavenProject project) throws Exception {
+    MavenSession session = runtime.newMavenSession(project.getBasedir());
+    session.setCurrentProject(project);
+    session.setProjects(Arrays.asList(project));
+    return session;
+  }
+
+  /** @since 2.9 */
+  public MojoExecution newMojoExecution(String goal, Xpp3Dom... parameters) {
+    MojoExecution execution = runtime.newMojoExecution(goal);
+    if (parameters != null) {
+      // TODO decide if this should go to runtime.newMojoExecution
+      Xpp3Dom configuration = execution.getConfiguration();
+      for (Xpp3Dom parameter : parameters) {
+        configuration.addChild(parameter);
+      }
+    }
+    return execution;
+  }
+
+  public void executeMojo(File basedir, String goal, Xpp3Dom... parameters) throws Exception {
+    MavenProject project = readMavenProject(basedir);
+    MavenSession session = newMavenSession(project);
+    executeMojo(session, project, goal, parameters);
+  }
+
+  public void executeMojo(MavenSession session, MavenProject project, String goal, Xpp3Dom... parameters) throws Exception {
+    MojoExecution execution = newMojoExecution(goal, parameters);
+    executeMojo(session, project, execution);
+  }
+
+  public void executeMojo(MavenProject project, String goal, Xpp3Dom... parameters) throws Exception {
+    MavenSession session = newMavenSession(project);
+    executeMojo(session, project, goal, parameters);
+  }
+
+  public void executeMojo(MavenSession session, MavenProject project, MojoExecution execution) throws Exception {
+    runtime.executeMojo(session, project, execution);
+  }
+
+  public Mojo lookupConfiguredMojo(MavenSession session, MojoExecution execution) throws Exception {
+    return runtime.lookupConfiguredMojo(session, execution);
+  }
+
+  public DefaultPlexusContainer getContainer() {
+    return runtime.getContainer();
+  }
+
+  public <T> T lookup(Class<T> role) throws Exception {
+    return runtime.lookup(role);
+  }
+
+  public static Xpp3Dom newParameter(String name, String value) {
+    Xpp3Dom child = new Xpp3Dom(name);
+    child.setValue(value);
+    return child;
+  }
+
+  public TestDependency newDependency(File artifact) {
+    return new TestDependency(artifact);
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/AbstractTestResources.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/AbstractTestResources.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.codehaus.plexus.util.DirectoryScanner;
+import org.codehaus.plexus.util.FileUtils;
+import org.junit.Assert;
+
+/**
+ * Abstract base class to extract and assert test resources.
+ */
+public abstract class AbstractTestResources {
+
+  private final String projectsDir;
+
+  private final String workDir;
+
+  private String name;
+
+  AbstractTestResources() {
+    this("src/test/projects", "target/test-projects");
+  }
+
+  AbstractTestResources(String projectsDir, String workDir) {
+    this.projectsDir = projectsDir;
+    this.workDir = workDir;
+  }
+
+  void starting(Class<?> testClass, String methodName) {
+    if (methodName != null) {
+      methodName = methodName.replace('/', '_').replace('\\', '_');
+    }
+    name = testClass.getSimpleName() + "_" + methodName;
+  }
+  
+  abstract String getRequiredAnnotationClassName();
+
+  /**
+   * Creates new clean copy of test project directory structure. The copy is named after both the test being executed and test project name, which allows the same test project can be used by multiple
+   * tests and by different instances of the same parametrized tests.<br/>
+   * TODO Provide alternative working directory naming for Windows, which still limits path names to ~250 charecters
+   */
+  public File getBasedir(String project) throws IOException {
+    if (name == null) {
+      throw new IllegalStateException(getClass().getSimpleName() + " must be a test class field annotated with " + getRequiredAnnotationClassName());
+    }
+    File basedir = new File(workDir, name + "_" + project).getCanonicalFile();
+    FileUtils.deleteDirectory(basedir);
+    Assert.assertTrue("Test project working directory created", basedir.mkdirs());
+    File src = new File(projectsDir, project).getCanonicalFile();
+    Assert.assertTrue("Test project directory does not exist: " + src.getPath(), src.isDirectory());
+    FileUtils.copyDirectoryStructure(src, basedir);
+    return basedir;
+  }
+
+  /**
+   * Creates new clean test work directory. The directory is named after test being executed.
+   * 
+   * @since 2.2
+   */
+  public File getBasedir() throws IOException {
+    if (name == null) {
+      throw new IllegalStateException(getClass().getSimpleName() + " must be a test class field annotated with " + getRequiredAnnotationClassName());
+    }
+    File basedir = new File(workDir, name).getCanonicalFile();
+    FileUtils.deleteDirectory(basedir);
+    Assert.assertTrue("Test project working directory created", basedir.mkdirs());
+    return basedir;
+  }
+
+  // static helpers
+
+  public static void cp(File basedir, String from, String to) throws IOException {
+    // TODO ensure destination lastModified timestamp changes
+    FileUtils.copyFile(new File(basedir, from), new File(basedir, to));
+  }
+
+  public static void assertFileContents(File basedir, String expectedPath, String actualPath) throws IOException {
+    String expected = fileRead(new File(basedir, expectedPath), true);
+    String actual = fileRead(new File(basedir, actualPath), true);
+    Assert.assertEquals(expected, actual);
+  }
+
+  private static String fileRead(File file, boolean normalizeEOL) throws IOException {
+    StringBuilder sb = new StringBuilder();
+    try (BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(file)))) {
+      if (normalizeEOL) {
+        String str;
+        while ((str = r.readLine()) != null) {
+          sb.append(str).append('\n');
+        }
+      } else {
+        int ch;
+        while ((ch = r.read()) != -1) {
+          sb.append((char) ch);
+        }
+      }
+    }
+    return sb.toString();
+  }
+
+  public static void assertFileContents(String expectedContents, File basedir, String path) throws IOException {
+    String actualContents = fileRead(new File(basedir, path), true);
+    Assert.assertEquals(expectedContents, actualContents);
+  }
+
+  public static void assertDirectoryContents(File dir, String... expectedPaths) {
+    DirectoryScanner scanner = new DirectoryScanner();
+    scanner.setBasedir(dir);
+    scanner.addDefaultExcludes();
+    scanner.scan();
+
+    Set<String> actual = new TreeSet<String>();
+    for (String path : scanner.getIncludedFiles()) {
+      actual.add(path.replace(File.separatorChar, '/'));
+    }
+    for (String path : scanner.getIncludedDirectories()) {
+      if (path.length() > 0) {
+        actual.add(path.replace(File.separatorChar, '/') + "/");
+      }
+    }
+
+    Set<String> expected = new TreeSet<String>();
+    if (expectedPaths != null) {
+      for (String path : expectedPaths) {
+        expected.add(path.replace(File.separatorChar, '/'));
+      }
+    }
+
+    // compare textual representation to make diff easier to understand
+    Assert.assertEquals(toString(expected), toString(actual));
+  }
+
+  private static String toString(Collection<String> strings) {
+    StringBuilder sb = new StringBuilder();
+    for (String string : strings) {
+      sb.append(string).append('\n');
+    }
+    return sb.toString();
+  }
+
+  public static void touch(File basedir, String path) throws InterruptedException {
+    touch(new File(basedir, path));
+  }
+
+  public static void touch(File file) throws InterruptedException {
+    if (!file.isFile()) {
+      throw new IllegalArgumentException("Not a file " + file);
+    }
+    long lastModified = file.lastModified();
+    file.setLastModified(System.currentTimeMillis());
+
+    // TODO do modern filesystems still have this silly lastModified resolution?
+    if (lastModified == file.lastModified()) {
+      Thread.sleep(1000L);
+      file.setLastModified(System.currentTimeMillis());
+    }
+  }
+
+  public static void rm(File basedir, String path) {
+    Assert.assertTrue("delete " + path, new File(basedir, path).delete());
+  }
+
+  public static void create(File basedir, String... paths) throws IOException {
+    if (paths == null || paths.length == 0) {
+      throw new IllegalArgumentException();
+    }
+    for (String path : paths) {
+      File file = new File(basedir, path);
+      file.getParentFile().mkdirs();
+      Assert.assertTrue(file.getParentFile().isDirectory());
+      file.createNewFile();
+      Assert.assertTrue(file.isFile() && file.canRead());
+    }
+  }
+
+  public static void assertFilesPresent(File basedir, String... paths) {
+    if (basedir == null || paths == null || paths.length <= 0) {
+      throw new IllegalArgumentException();
+    }
+    if (paths.length == 1) {
+      Assert.assertTrue(paths[0] + " PRESENT", new File(basedir, paths[0]).isFile());
+    } else {
+      StringBuilder expected = new StringBuilder();
+      StringBuilder actual = new StringBuilder();
+      for (String path : paths) {
+        expected.append(path).append("\n");
+        if (!new File(basedir, path).isFile()) {
+          actual.append("NOT PRESENT ");
+        }
+        actual.append(path).append("\n");
+      }
+      Assert.assertEquals(expected.toString(), actual.toString());
+    }
+  }
+
+  public static void assertFilesNotPresent(File basedir, String... paths) {
+    if (basedir == null || paths == null || paths.length <= 0) {
+      throw new IllegalArgumentException();
+    }
+    if (paths.length == 1) {
+      Assert.assertFalse(paths[0] + " NOT PRESENT", new File(basedir, paths[0]).isFile());
+    } else {
+      StringBuilder expected = new StringBuilder();
+      StringBuilder actual = new StringBuilder();
+      for (String path : paths) {
+        expected.append(path).append("\n");
+        if (new File(basedir, path).isFile()) {
+          actual.append("PRESENT ");
+        }
+        actual.append(path).append("\n");
+      }
+      Assert.assertEquals(expected.toString(), actual.toString());
+    }
+  }
+
+  /**
+   * @since 2.2
+   */
+  public static Map<String, String> readProperties(File basedir, String path) throws IOException {
+    Properties properties = new Properties();
+    try (InputStream is = new FileInputStream(new File(basedir, path))) {
+      properties.load(is);
+    }
+    Map<String, String> result = new HashMap<>();
+    for (String key : properties.stringPropertyNames()) {
+      result.put(key, properties.getProperty(key));
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/TestMavenRuntime.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/TestMavenRuntime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Takari, Inc.
+ * Copyright (c) 2014-2021 Takari, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,195 +7,20 @@
  */
 package io.takari.maven.testing;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.handler.ArtifactHandler;
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
-import org.apache.maven.artifact.versioning.VersionRange;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.Mojo;
-import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.DefaultPlexusContainer;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.junit.Assert;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import com.google.inject.Module;
 
-public class TestMavenRuntime implements TestRule {
-
-  private static final DefaultArtifactVersion MAVEN_VERSION;
-
-  static {
-    DefaultArtifactVersion version = null;
-    String path = "/META-INF/maven/org.apache.maven/maven-core/pom.properties";
-    try (InputStream is = TestMavenRuntime.class.getResourceAsStream(path)) {
-      Properties properties = new Properties();
-      if (is != null) {
-        properties.load(is);
-      }
-      String property = properties.getProperty("version");
-      if (property != null) {
-        version = new DefaultArtifactVersion(property);
-      }
-    } catch (IOException e) {
-      // odd, where did this come from
-    }
-    MAVEN_VERSION = version;
-  }
-
-  private static interface RuntimeFactory {
-    MavenRuntime newInstance(Module[] modules) throws Exception;
-  }
-
-  // ordered map of supported maven runtime factories
-  private static final Map<VersionRange, RuntimeFactory> FACTORIES;
-
-  static {
-    Map<VersionRange, RuntimeFactory> factories = new LinkedHashMap<>();
-    try {
-      factories.put(VersionRange.createFromVersionSpec("[3.0,3.1.1)"), new RuntimeFactory() {
-        @Override
-        public MavenRuntime newInstance(Module[] modules) throws Exception {
-          return new Maven30xRuntime(modules);
-        }
-      });
-      factories.put(VersionRange.createFromVersionSpec("[3.1.1,3.2.1)"), new RuntimeFactory() {
-        @Override
-        public MavenRuntime newInstance(Module[] modules) throws Exception {
-          return new Maven311Runtime(modules);
-        }
-      });
-      factories.put(VersionRange.createFromVersionSpec("[3.2.1,3.2.5)"), new RuntimeFactory() {
-        @Override
-        public MavenRuntime newInstance(Module[] modules) throws Exception {
-          return Maven321Runtime.create(modules);
-        }
-      });
-      factories.put(VersionRange.createFromVersionSpec("[3.2.5]"), new RuntimeFactory() {
-        @Override
-        public MavenRuntime newInstance(Module[] modules) throws Exception {
-          return new Maven325Runtime(modules);
-        }
-      });
-      // the last entry is expected to handle everything else
-      factories.put(VersionRange.createFromVersionSpec("(3.2.5,]"), new RuntimeFactory() {
-        @Override
-        public MavenRuntime newInstance(Module[] modules) throws Exception {
-          return new Maven331Runtime(modules);
-        }
-      });
-    } catch (InvalidVersionSpecificationException e) {
-      throw new RuntimeException(e);
-    }
-    FACTORIES = Collections.unmodifiableMap(factories);
-  }
-
-  private final Module[] modules;
-  private MavenRuntime runtime;
-
-  public class TestDependency {
-
-    private final File file;
-    private String groupId = "test";
-    private String artifactId;
-    private String classifier;
-    private String version = "1.0";
-    private String type = "jar";
-    private String scope = Artifact.SCOPE_COMPILE;
-    private boolean optional;
-
-    private TestDependency(File artifact) {
-      this.file = artifact;
-      this.artifactId = artifact.getName();
-    }
-
-    public TestDependency setArtifactId(String artifactId) {
-      this.artifactId = artifactId;
-
-      return this;
-    }
-
-    public TestDependency setGroupId(String groupId) {
-      this.groupId = groupId;
-
-      return this;
-    }
-
-    public TestDependency setVersion(String version) {
-      this.version = version;
-
-      return this;
-    }
-
-    public TestDependency setType(String type) {
-      this.type = type;
-
-      return this;
-    }
-
-    public TestDependency setOptional(boolean optional) {
-      this.optional = optional;
-
-      return this;
-    }
-
-    public TestDependency setClassifier(String classifier) {
-      this.classifier = classifier;
-
-      return this;
-    }
-
-    public TestDependency setScope(String scope) {
-      this.scope = scope;
-
-      return this;
-    }
-
-    public TestDependency addTo(MavenProject project) throws Exception {
-      return addTo(project, true);
-    }
-
-    public TestDependency addTo(MavenProject project, boolean direct) throws Exception {
-      ArtifactHandler handler = getContainer().lookup(ArtifactHandler.class, type);
-      DefaultArtifact artifact = new DefaultArtifact(groupId, artifactId, version, scope, type, classifier, handler);
-      artifact.setFile(file);
-      artifact.setOptional(optional);
-      Set<Artifact> artifacts = project.getArtifacts();
-      artifacts.add(artifact);
-      project.setArtifacts(artifacts);
-      if (direct) {
-        Set<Artifact> directDependencies = project.getDependencyArtifacts();
-        directDependencies = directDependencies == null ? new LinkedHashSet<Artifact>() : new LinkedHashSet<>(directDependencies);
-        directDependencies.add(artifact);
-        project.setDependencyArtifacts(directDependencies);
-      }
-
-      return this;
-    }
-  }
+public class TestMavenRuntime extends AbstractTestMavenRuntime implements TestRule {
 
   public TestMavenRuntime() {
-    this(new Module[0]);
+    super();
   }
 
   public TestMavenRuntime(Module... modules) {
-    this.modules = modules;
+    super(modules);
   }
 
   @Override
@@ -203,92 +28,14 @@ public class TestMavenRuntime implements TestRule {
     return new Statement() {
       @Override
       public void evaluate() throws Throwable {
-        runtime = newMavenRuntime(modules);
+        createMavenRuntime();
         try {
           base.evaluate();
         } finally {
-          runtime.shutdown();
-          runtime = null;
+          shutDownMavenRuntime();
         }
       }
     };
-  }
-
-  private MavenRuntime newMavenRuntime(Module[] modules) throws Exception {
-    for (Map.Entry<VersionRange, RuntimeFactory> entry : FACTORIES.entrySet()) {
-      if (entry.getKey().containsVersion(MAVEN_VERSION)) {
-        return entry.getValue().newInstance(modules);
-      }
-    }
-    throw new AssertionError(String.format("Maven version %s is not supported, supprted versions: %s", MAVEN_VERSION, FACTORIES.entrySet()));
-  }
-
-  public MavenProject readMavenProject(File basedir) throws Exception {
-    MavenProject project = runtime.readMavenProject(basedir);
-    Assert.assertNotNull(project);
-    return project;
-  }
-
-  public MavenSession newMavenSession(MavenProject project) throws Exception {
-    MavenSession session = runtime.newMavenSession(project.getBasedir());
-    session.setCurrentProject(project);
-    session.setProjects(Arrays.asList(project));
-    return session;
-  }
-
-  /** @since 2.9 */
-  public MojoExecution newMojoExecution(String goal, Xpp3Dom... parameters) {
-    MojoExecution execution = runtime.newMojoExecution(goal);
-    if (parameters != null) {
-      // TODO decide if this should go to runtime.newMojoExecution
-      Xpp3Dom configuration = execution.getConfiguration();
-      for (Xpp3Dom parameter : parameters) {
-        configuration.addChild(parameter);
-      }
-    }
-    return execution;
-  }
-
-  public void executeMojo(File basedir, String goal, Xpp3Dom... parameters) throws Exception {
-    MavenProject project = readMavenProject(basedir);
-    MavenSession session = newMavenSession(project);
-    executeMojo(session, project, goal, parameters);
-  }
-
-  public void executeMojo(MavenSession session, MavenProject project, String goal, Xpp3Dom... parameters) throws Exception {
-    MojoExecution execution = newMojoExecution(goal, parameters);
-    executeMojo(session, project, execution);
-  }
-
-  public void executeMojo(MavenProject project, String goal, Xpp3Dom... parameters) throws Exception {
-    MavenSession session = newMavenSession(project);
-    executeMojo(session, project, goal, parameters);
-  }
-
-  public void executeMojo(MavenSession session, MavenProject project, MojoExecution execution) throws Exception {
-    runtime.executeMojo(session, project, execution);
-  }
-
-  public Mojo lookupConfiguredMojo(MavenSession session, MojoExecution execution) throws Exception {
-    return runtime.lookupConfiguredMojo(session, execution);
-  }
-
-  public DefaultPlexusContainer getContainer() {
-    return runtime.getContainer();
-  }
-
-  public <T> T lookup(Class<T> role) throws Exception {
-    return runtime.lookup(role);
-  }
-
-  public static Xpp3Dom newParameter(String name, String value) {
-    Xpp3Dom child = new Xpp3Dom(name);
-    child.setValue(value);
-    return child;
-  }
-
-  public TestDependency newDependency(File artifact) {
-    return new TestDependency(artifact);
   }
 
 }

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/TestMavenRuntime5.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/TestMavenRuntime5.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.google.inject.Module;
+
+/**
+ * Like {@link TestMavenRuntime} but for JUnit 5.
+ * 
+ * @author Philippe Marschall
+ */
+public class TestMavenRuntime5 extends AbstractTestMavenRuntime implements BeforeEachCallback, AfterEachCallback {
+
+  public TestMavenRuntime5() {
+    super();
+  }
+
+  public TestMavenRuntime5(Module... modules) {
+    super(modules);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    createMavenRuntime();
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    shutDownMavenRuntime();
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/TestResources.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/TestResources.java
@@ -7,269 +7,38 @@
  */
 package io.takari.maven.testing;
 
-import java.io.BufferedReader;
-
-// some of the code was originally copied from org.apache.maven.plugin.testing.resources.TestResources
-
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
-
-import org.codehaus.plexus.util.DirectoryScanner;
-import org.codehaus.plexus.util.FileUtils;
-import org.junit.Assert;
 import org.junit.Rule;
-import org.junit.rules.TestWatcher;
+import org.junit.rules.TestRule;
 import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 /**
  * Junit4 test {@link Rule} to extract and assert test resources.
  */
-public class TestResources extends TestWatcher {
-
-  private final String projectsDir;
-
-  private final String workDir;
-
-  private String name;
+public class TestResources extends AbstractTestResources implements TestRule {
 
   public TestResources() {
-    this("src/test/projects", "target/test-projects");
+    super();
   }
 
   public TestResources(String projectsDir, String workDir) {
-    this.projectsDir = projectsDir;
-    this.workDir = workDir;
+    super(projectsDir, workDir);
   }
 
   @Override
-  protected void starting(Description d) {
-    String methodName = d.getMethodName();
-    if (methodName != null) {
-      methodName = methodName.replace('/', '_').replace('\\', '_');
-    }
-    name = d.getTestClass().getSimpleName() + "_" + methodName;
-  }
-
-  /**
-   * Creates new clean copy of test project directory structure. The copy is named after both the test being executed and test project name, which allows the same test project can be used by multiple
-   * tests and by different instances of the same parametrized tests.<br/>
-   * TODO Provide alternative working directory naming for Windows, which still limits path names to ~250 charecters
-   */
-  public File getBasedir(String project) throws IOException {
-    if (name == null) {
-      throw new IllegalStateException(getClass().getSimpleName() + " must be a test class field annotated with org.junit.Rule");
-    }
-    File basedir = new File(workDir, name + "_" + project).getCanonicalFile();
-    FileUtils.deleteDirectory(basedir);
-    Assert.assertTrue("Test project working directory created", basedir.mkdirs());
-    File src = new File(projectsDir, project).getCanonicalFile();
-    Assert.assertTrue("Test project directory does not exist: " + src.getPath(), src.isDirectory());
-    FileUtils.copyDirectoryStructure(src, basedir);
-    return basedir;
-  }
-
-  /**
-   * Creates new clean test work directory. The directory is named after test being executed.
-   * 
-   * @since 2.2
-   */
-  public File getBasedir() throws IOException {
-    if (name == null) {
-      throw new IllegalStateException(getClass().getSimpleName() + " must be a test class field annotated with org.junit.Rule");
-    }
-    File basedir = new File(workDir, name).getCanonicalFile();
-    FileUtils.deleteDirectory(basedir);
-    Assert.assertTrue("Test project working directory created", basedir.mkdirs());
-    return basedir;
-  }
-
-  // static helpers
-
-  public static void cp(File basedir, String from, String to) throws IOException {
-    // TODO ensure destination lastModified timestamp changes
-    FileUtils.copyFile(new File(basedir, from), new File(basedir, to));
-  }
-
-  public static void assertFileContents(File basedir, String expectedPath, String actualPath) throws IOException {
-    String expected = fileRead(new File(basedir, expectedPath), true);
-    String actual = fileRead(new File(basedir, actualPath), true);
-    Assert.assertEquals(expected, actual);
-  }
-
-  private static String fileRead(File file, boolean normalizeEOL) throws IOException {
-    StringBuilder sb = new StringBuilder();
-    try (BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(file)))) {
-      if (normalizeEOL) {
-        String str;
-        while ((str = r.readLine()) != null) {
-          sb.append(str).append('\n');
-        }
-      } else {
-        int ch;
-        while ((ch = r.read()) != -1) {
-          sb.append((char) ch);
-        }
+  public Statement apply(Statement base, Description d) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        starting(d.getTestClass(), d.getMethodName());
+        base.evaluate();
       }
-    }
-    return sb.toString();
+    };
   }
 
-  public static void assertFileContents(String expectedContents, File basedir, String path) throws IOException {
-    String actualContents = fileRead(new File(basedir, path), true);
-    Assert.assertEquals(expectedContents, actualContents);
+  @Override
+  String getRequiredAnnotationClassName() {
+    return "org.junit.Rule";
   }
 
-  public static void assertDirectoryContents(File dir, String... expectedPaths) {
-    DirectoryScanner scanner = new DirectoryScanner();
-    scanner.setBasedir(dir);
-    scanner.addDefaultExcludes();
-    scanner.scan();
-
-    Set<String> actual = new TreeSet<String>();
-    for (String path : scanner.getIncludedFiles()) {
-      actual.add(path.replace(File.separatorChar, '/'));
-    }
-    for (String path : scanner.getIncludedDirectories()) {
-      if (path.length() > 0) {
-        actual.add(path.replace(File.separatorChar, '/') + "/");
-      }
-    }
-
-    Set<String> expected = new TreeSet<String>();
-    if (expectedPaths != null) {
-      for (String path : expectedPaths) {
-        expected.add(path.replace(File.separatorChar, '/'));
-      }
-    }
-
-    // compare textual representation to make diff easier to understand
-    Assert.assertEquals(toString(expected), toString(actual));
-  }
-
-  private static String toString(Collection<String> strings) {
-    StringBuilder sb = new StringBuilder();
-    for (String string : strings) {
-      sb.append(string).append('\n');
-    }
-    return sb.toString();
-  }
-
-  public static void touch(File basedir, String path) throws InterruptedException {
-    touch(new File(basedir, path));
-  }
-
-  public static void touch(File file) throws InterruptedException {
-    if (!file.isFile()) {
-      throw new IllegalArgumentException("Not a file " + file);
-    }
-    long lastModified = file.lastModified();
-    file.setLastModified(System.currentTimeMillis());
-
-    // TODO do modern filesystems still have this silly lastModified resolution?
-    if (lastModified == file.lastModified()) {
-      Thread.sleep(1000L);
-      file.setLastModified(System.currentTimeMillis());
-    }
-  }
-
-  public static void rm(File basedir, String path) {
-    Assert.assertTrue("delete " + path, new File(basedir, path).delete());
-  }
-
-  public static void create(File basedir, String... paths) throws IOException {
-    if (paths == null || paths.length == 0) {
-      throw new IllegalArgumentException();
-    }
-    for (String path : paths) {
-      File file = new File(basedir, path);
-      file.getParentFile().mkdirs();
-      Assert.assertTrue(file.getParentFile().isDirectory());
-      file.createNewFile();
-      Assert.assertTrue(file.isFile() && file.canRead());
-    }
-  }
-
-  public static void assertFilesPresent(File basedir, String... paths) {
-    if (basedir == null || paths == null || paths.length <= 0) {
-      throw new IllegalArgumentException();
-    }
-    if (paths.length == 1) {
-      Assert.assertTrue(paths[0] + " PRESENT", new File(basedir, paths[0]).isFile());
-    } else {
-      StringBuilder expected = new StringBuilder();
-      StringBuilder actual = new StringBuilder();
-      for (String path : paths) {
-        expected.append(path).append("\n");
-        if (!new File(basedir, path).isFile()) {
-          actual.append("NOT PRESENT ");
-        }
-        actual.append(path).append("\n");
-      }
-      Assert.assertEquals(expected.toString(), actual.toString());
-    }
-  }
-
-  public static void assertFilesNotPresent(File basedir, String... paths) {
-    if (basedir == null || paths == null || paths.length <= 0) {
-      throw new IllegalArgumentException();
-    }
-    if (paths.length == 1) {
-      Assert.assertFalse(paths[0] + " NOT PRESENT", new File(basedir, paths[0]).isFile());
-    } else {
-      StringBuilder expected = new StringBuilder();
-      StringBuilder actual = new StringBuilder();
-      for (String path : paths) {
-        expected.append(path).append("\n");
-        if (new File(basedir, path).isFile()) {
-          actual.append("PRESENT ");
-        }
-        actual.append(path).append("\n");
-      }
-      Assert.assertEquals(expected.toString(), actual.toString());
-    }
-  }
-
-  /**
-   * @since 2.2
-   */
-  public static Map<String, String> readProperties(File basedir, String path) throws IOException {
-    Properties properties = new Properties();
-    try (InputStream is = new FileInputStream(new File(basedir, path))) {
-      properties.load(is);
-    }
-    Map<String, String> result = new HashMap<>();
-    for (String key : properties.stringPropertyNames()) {
-      result.put(key, properties.getProperty(key));
-    }
-    return Collections.unmodifiableMap(result);
-  }
 }

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/TestResources5.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/TestResources5.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension to extract and assert test resources.
+ */
+public class TestResources5 extends AbstractTestResources implements BeforeEachCallback {
+
+  public TestResources5() {
+    super();
+  }
+
+  public TestResources5(String projectsDir, String workDir) {
+    super(projectsDir, workDir);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    String methodName = context.getTestMethod().map(Method::getName).orElse(null);
+    starting(context.getRequiredTestClass(), methodName);
+  }
+  
+  @Override
+  String getRequiredAnnotationClassName() {
+    return "org.junit.jupiter.api.extension.RegisterExtension";
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/ForcedMavenRuntimeBuilderParameterResolver.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/ForcedMavenRuntimeBuilderParameterResolver.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+import java.io.File;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import io.takari.maven.testing.executor.MavenInstallationUtils;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+
+/**
+ * Provides a {@link MavenRuntimeBuilder} based on {@code -Dmaven.home}
+ * and optionally {@code -Dclassworlds.conf}.
+ * 
+ * @author Philippe Marschall
+ */
+final class ForcedMavenRuntimeBuilderParameterResolver implements ParameterResolver {
+
+  ForcedMavenRuntimeBuilderParameterResolver() {
+    super();
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    return (parameterContext.getParameter().getType() == MavenRuntimeBuilder.class)
+        && MavenHomeUtils.isForced();
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    File forcedMavenHome = MavenInstallationUtils.getForcedMavenHome();
+    File forcedClassworldsConf = MavenInstallationUtils.getForcedClassworldsConf();
+
+    if (forcedMavenHome != null) {
+      if (forcedMavenHome.isDirectory() || ((forcedClassworldsConf != null) && forcedClassworldsConf.isFile())) {
+        return MavenRuntime.builder(forcedMavenHome, forcedClassworldsConf);
+      }
+    }
+    throw new ParameterResolutionException("Invalid -Dmaven.home=" + forcedMavenHome.getAbsolutePath());
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenHomeUtils.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenHomeUtils.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+import java.io.File;
+
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+
+import io.takari.maven.testing.executor.MavenInstallationUtils;
+
+final class MavenHomeUtils {
+
+  private MavenHomeUtils() {
+    throw new AssertionError("not instantiable");
+  }
+
+  static boolean isForced() {
+
+    File forcedMavenHome = MavenInstallationUtils.getForcedMavenHome();
+    File forcedClassworldsConf = MavenInstallationUtils.getForcedClassworldsConf();
+
+    if (forcedMavenHome != null) {
+      if (forcedMavenHome.isDirectory() || (forcedClassworldsConf != null && forcedClassworldsConf.isFile())) {
+        return true;
+      }
+      throw new ExtensionConfigurationException("Invalid -Dmaven.home=" + forcedMavenHome.getAbsolutePath());
+    }
+    return false;
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenInstallationDisplayNameFormatter.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenInstallationDisplayNameFormatter.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+final class MavenInstallationDisplayNameFormatter {
+
+  private final String displayName;
+
+  MavenInstallationDisplayNameFormatter(String displayName) {
+    this.displayName = displayName;
+  }
+
+  String format(String mavenInstallation) {
+    return this.displayName + '[' + mavenInstallation + ']';
+  }
+  
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenInstallationTestInvocationContext.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenInstallationTestInvocationContext.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+final class MavenInstallationTestInvocationContext implements TestTemplateInvocationContext {
+
+  private final MavenInstallationDisplayNameFormatter formatter;
+  private final String installation;
+
+  MavenInstallationTestInvocationContext(String installation, MavenInstallationDisplayNameFormatter formatter) {
+    this.installation = installation;
+    this.formatter = formatter;
+  }
+
+  @Override
+  public String getDisplayName(int invocationIndex) {
+    return this.formatter.format(this.installation);
+  }
+
+  @Override
+  public List<Extension> getAdditionalExtensions() {
+    File mavenHome;
+    try {
+      mavenHome = new File(this.installation).getCanonicalFile();
+    } catch (IOException e) {
+      throw new ExtensionConfigurationException("could not access maven installation: " + this.installation, e);
+    }
+    if (mavenHome.isDirectory()) {
+      return Collections.singletonList(new MavenRuntimeBuilderParameterResolver(mavenHome));
+    } else {
+      throw new ExtensionConfigurationException("Invalid maven installation location " + installation);
+    }
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenInstallationsTestExtension.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenInstallationsTestExtension.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import io.takari.maven.testing.executor.MavenInstallations;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+
+/**
+ * Provides a {@link TestTemplateInvocationContext} with a {@link MavenRuntimeBuilder}
+ * for each Maven installation configured through {@link MavenInstallations}.
+ * <p>
+ * Not active if Maven home is forced through {@code -Dmaven.home}.
+ * 
+ * @author Philippe Marschall
+ */
+final class MavenInstallationsTestExtension implements TestTemplateInvocationContextProvider {
+
+  @Override
+  public boolean supportsTestTemplate(ExtensionContext context) {
+    if (MavenHomeUtils.isForced()) {
+      return false;
+    }
+    //@formatter:off
+    return context.getTestClass()
+                  .map(clazz -> clazz.isAnnotationPresent(MavenInstallations.class))
+                  .orElse(false);
+    //@formatter:on
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+    String displayName = context.getDisplayName();
+    String[] installations = context.getTestClass().get().getAnnotation(MavenInstallations.class).value();
+    return Arrays.stream(installations)
+        .map(installation -> new MavenInstallationTestInvocationContext(installation, new MavenInstallationDisplayNameFormatter(displayName)));
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenPluginTest.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenPluginTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Meta-annotation for Maven plugin integration tests, registers all necessary extensions.
+ * 
+ * @author Philippe Marschall
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ANNOTATION_TYPE, METHOD})
+@TestTemplate
+@Inherited
+@ExtendWith({
+  ForcedMavenRuntimeBuilderParameterResolver.class,
+  MavenInstallationsTestExtension.class,
+  MavenVersionsTestExtension.class})
+public @interface MavenPluginTest {
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenRuntimeBuilderParameterResolver.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenRuntimeBuilderParameterResolver.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+import java.io.File;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+
+final class MavenRuntimeBuilderParameterResolver implements ParameterResolver {
+  
+  private final File mavenHome;
+
+  MavenRuntimeBuilderParameterResolver(File mavenHome) {
+    this.mavenHome = mavenHome;
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    return parameterContext.getParameter().getType() == MavenRuntimeBuilder.class;
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return  MavenRuntime.builder(this.mavenHome, null);
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenVersionDisplayNameFormatter.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenVersionDisplayNameFormatter.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+final class MavenVersionDisplayNameFormatter {
+
+  private final String displayName;
+
+  MavenVersionDisplayNameFormatter(String displayName) {
+    this.displayName = displayName;
+  }
+
+  String format(String mavenVersion) {
+    return this.displayName + '[' + mavenVersion + ']';
+  }
+  
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenVersionTestInvocationContext.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenVersionTestInvocationContext.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+final class MavenVersionTestInvocationContext implements TestTemplateInvocationContext {
+
+  private final String mavenVersion;
+  private final File mavenHome;
+  private final MavenVersionDisplayNameFormatter formatter;
+
+  MavenVersionTestInvocationContext(String mavenVersion, File mavenHome, MavenVersionDisplayNameFormatter formatter) {
+    this.mavenVersion = mavenVersion;
+    this.mavenHome = mavenHome;
+    this.formatter = formatter;
+  }
+
+  @Override
+  public String getDisplayName(int invocationIndex) {
+    return this.formatter.format(this.mavenVersion);
+  }
+
+  @Override
+  public List<Extension> getAdditionalExtensions() {
+    return Collections.singletonList(new MavenRuntimeBuilderParameterResolver(this.mavenHome));
+  }
+
+}

--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenVersionsTestExtension.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenVersionsTestExtension.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2021 Takari, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.testing.executor.junit;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.runners.model.InitializationError;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+
+/**
+ * Provides a {@link TestTemplateInvocationContext} with a {@link MavenRuntimeBuilder}
+ * for each Maven version configured through {@link MavenVersions}.
+ * <p>
+ * Not active if Maven home is forced through {@code -Dmaven.home}.
+ * 
+ * @author Philippe Marschall
+ */
+final class MavenVersionsTestExtension implements TestTemplateInvocationContextProvider {
+
+  @Override
+  public boolean supportsTestTemplate(ExtensionContext context) {
+    if (MavenHomeUtils.isForced()) {
+      return false;
+    }
+    //@formatter:off
+    return context.getTestClass()
+                  .map(clazz -> clazz.isAnnotationPresent(MavenVersions.class))
+                  .orElse(false);
+    //@formatter:on
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+    String displayName = context.getDisplayName();
+    String[] versions = context.getTestClass().get().getAnnotation(MavenVersions.class).value();
+    List<TestTemplateInvocationContext> contexts = new ArrayList<>();
+    List<Throwable> errors = new ArrayList<>();
+
+    try {
+      new MavenVersionResolver() {
+        @Override
+        protected void resolved(File mavenHome, String version) throws InitializationError {
+          contexts.add(new MavenVersionTestInvocationContext(version, mavenHome, new MavenVersionDisplayNameFormatter(displayName)));
+        }
+
+        @Override
+        protected void error(String version, Exception cause) {
+          errors.add(new Exception("Could not resolve maven version " + version, cause));
+        }
+      }.resolve(versions);
+    } catch (Exception e) {
+      throw new ExtensionConfigurationException("Could not resolve maven versions", e);
+    }
+    if (!errors.isEmpty()) {
+      ExtensionConfigurationException extensionConfigurationException = new ExtensionConfigurationException("Could not resolve maven versions");
+      for (Throwable error : errors) {
+        extensionConfigurationException.addSuppressed(error);
+      }
+      throw extensionConfigurationException;
+    }
+    return contexts.stream();
+  }
+
+}


### PR DESCRIPTION
This pr adds support for JUnit 5 along side JUnit 4.

The chosen approach focuses on maximising code reuse while minimziging code changes.

The assertions in `AbstractTestResources` require JUnit 4 to always be present.

Different approaches are certainly possible, one would for example be to make dedicates module for JUnit 4 and JUnit 5.