### PR TITLE
fix: TestMavenRuntime5/AbstractTestMavenRuntime depend JUnit4

### DIFF
--- a/takari-plugin-testing/src/main/java/io/takari/maven/testing/AbstractTestMavenRuntime.java
+++ b/takari-plugin-testing/src/main/java/io/takari/maven/testing/AbstractTestMavenRuntime.java
@@ -39,7 +39,7 @@ public abstract class AbstractTestMavenRuntime {
     static {
         DefaultArtifactVersion version = null;
         String path = "/META-INF/maven/org.apache.maven/maven-core/pom.properties";
-        try (InputStream is = TestMavenRuntime.class.getResourceAsStream(path)) {
+        try (InputStream is = AbstractTestMavenRuntime.class.getResourceAsStream(path)) {
             Properties properties = new Properties();
             if (is != null) {
                 properties.load(is);


### PR DESCRIPTION
When excluding JUnit4 when using JUnit 5 like:
```xml
      <dependency>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-plugin-testing</artifactId>
         <version>3.0.4</version>
         <scope>test</scope>
         <exclusions>
            <exclusion>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
            </exclusion>
         </exclusions>
      </dependency>
```

the build fails with:

```py
java.lang.NoClassDefFoundError: org/junit/rules/TestRule
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1022)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:800)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:698)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:621)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:579)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
        at io.takari.maven.testing.AbstractTestMavenRuntime.<clinit>(AbstractTestMavenRuntime.java:42)
```

Because AbstractTestMavenRuntime references the JUnit4 TestMavenRuntime class.